### PR TITLE
Fixed spelling mistake

### DIFF
--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -178,7 +178,7 @@
     <string name="fallacies_examples_5_5">\'We\'re going to have to cut the education budget or go deeper into debt. We can\'t afford to go deeper into debt, so we\'ll have to cut the education budget.\'</string>
     <string name="fallacies_examples_5_6">\'I did not have sexual relations with that woman.\'</string>
     <string name="fallacies_examples_5_7">\'After legalizing gay marriage, school libraries were required to stock same-sex literature; primary school children were given homosexual fairy tales and even manuals of explicit homosexual advocacy.\'</string>
-    <string name="fallacies_examples_5_8">\'Why should the senator account for irregularities in his expenses? After all, these are senators who have done far worse things.\'</string>
+    <string name="fallacies_examples_5_8">\'Why should the senator account for irregularities in his expenses? After all, there are senators who have done far worse things.\'</string>
     <string name="fallacies_examples_5_9">\'If we legalize marijuana, more people will start using crack and heroin, then we\'d have to legalize those too.\'</string>
     <string name="fallacies_examples_5_10">\'This Iraqi regime possesses and produces chemical and biological weapons. It is seeking nuclear weapons.\'</string>
     <string name="fallacies_examples_5_11">\'He lied because he\'s possessed by demons.\'</string>


### PR DESCRIPTION
Chances the red herring example to say they're are other senators. A quick Google search suggests that "there" makes more sense than "these". https://www.google.com/search?q=account+for+irregularities+in+his+expenses%3F+After+all%2C+there+are+senators+who+have+done+far+worse+things&oq=account+for+irregularities+in+his+expenses%3F+After+all%2C+there+are+senators+who+have+done+far+worse+things&aqs=chrome..69i57.922j0j4&client=ms-android-google&sourceid=chrome-mobile&ie=UTF-8