### PR TITLE
Fix readme headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ An open source Android app that displays a list of the logical fallacies that ha
 [![Download from Google Play](http://www.android.com/images/brand/android_app_on_play_large.png "Download from Google Play")](https://play.google.com/store/apps/details?id=za.co.lukestonehm.logicaldefence)
 [![Logical Defence on fdroid.org](https://camo.githubusercontent.com/7df0eafa4433fa4919a56f87c3d99cf81b68d01c/68747470733a2f2f662d64726f69642e6f72672f77696b692f696d616765732f632f63342f462d44726f69642d627574746f6e5f617661696c61626c652d6f6e2e706e67 "Download from fdroid.org")](https://f-droid.org/repository/browse/?fdid=za.co.lukestonehm.logicaldefence)
 
-# License
+## License
 GNU GPL2+
 
-#Attributes
+## Attributes
 Brain icon was found on Icon Finder - https://www.iconfinder.com/icons/190293/brain_games_icon (could not find the author's website)


### PR DESCRIPTION
Markdown requires spaces after the hash symbols used to declare the headers.
These were not present, resulting in incorrect HTML generation. This commit
will add the required spaces. It will also reduce the header level for the
subtitles, from h1 to h2.